### PR TITLE
Create a single ClientSession.

### DIFF
--- a/student_agency_async.py
+++ b/student_agency_async.py
@@ -5,29 +5,30 @@ import aiohttp
 from bs4 import BeautifulSoup
 
 
-async def scrape_route(departure, arrival, date):
+async def scrape_route(session, departure, arrival, date):
     """Scrape all connections for a specific route and data."""
     print(f'Scraping route {departure} - {arrival} for {date}')
-    async with aiohttp.ClientSession() as session:
-        await session.get('https://jizdenky.regiojet.cz/m/')
-        form_data = aiohttp.FormData()
-        form_data.add_field('fromStation', departure)
-        form_data.add_field('toStation', arrival)
-        form_data.add_field('departure', date.strftime('%d.%m.%y'))
 
-        response = await session.post('https://jizdenky.regiojet.cz/m/?0-1.IFormSubmitListener-searchForm-form', data=form_data)
-        raw_body = await response.text()
-        html_body = BeautifulSoup(raw_body, 'html.parser')
-        routes = html_body.find_all(class_='select-line')  # Select bus connections only.
-        for route in routes:
-            bus_connection = route.get_text().split()
-            # Here is a place for further processing of results.
+    await session.get('https://jizdenky.regiojet.cz/m/')
+    form_data = aiohttp.FormData()
+    form_data.add_field('fromStation', departure)
+    form_data.add_field('toStation', arrival)
+    form_data.add_field('departure', date.strftime('%d.%m.%y'))
+
+    response = await session.post('https://jizdenky.regiojet.cz/m/?0-1.IFormSubmitListener-searchForm-form', data=form_data)
+    raw_body = await response.text()
+    html_body = BeautifulSoup(raw_body, 'html.parser')
+    routes = html_body.find_all(class_='select-line')  # Select bus connections only.
+    for route in routes:
+        bus_connection = route.get_text().split()
+        # Here is a place for further processing of results.
 
     print(f'Scraping COMPLETED {departure} - {arrival} for {date}')
 
 async def scrape_multiple_dates(departure, arrival, dates):
     """Scrape prices for a specifc route and multiple dates."""
-    await asyncio.gather(*[scrape_route(departure, arrival, date) for date in dates])
+    async with aiohttp.ClientSession() as session:
+        await asyncio.gather(*[scrape_route(session, departure, arrival, date) for date in dates])
 
 
 def main():


### PR DESCRIPTION
Makes the async test case finish significantly faster for me.

From the aiohttp documentation:

Session encapsulates a connection pool (connector instance) and supports
keepalives by default. Unless you are connecting to a large, unknown number
of different servers over the lifetime of your application, it is suggested
you use a single session for the lifetime of your application to benefit
from connection pooling.